### PR TITLE
feat: resolve postal codes from municipality names via WFS

### DIFF
--- a/src/api/routes/municipalities.ts
+++ b/src/api/routes/municipalities.ts
@@ -1,14 +1,23 @@
-import { MUNICIPALITIES, MUNICIPALITY_POSTAL_CODES } from '../../config/postalCodes.ts';
+import { sql } from '../db.ts';
 
 /**
  * GET /api/municipalities
  *
  * Returns the list of available municipalities with their postal code counts.
+ * Data sourced from the postal_code table in the database.
  */
 export async function getMunicipalities(): Promise<Response> {
-    const result = MUNICIPALITIES.map(name => ({
-        name,
-        postalCodeCount: MUNICIPALITY_POSTAL_CODES[name].length,
+    const rows = await sql`
+        SELECT municipality AS name, COUNT(*) AS postal_code_count
+        FROM postal_code
+        WHERE municipality IS NOT NULL
+        GROUP BY municipality
+        ORDER BY municipality
+    `;
+
+    const result = rows.map(r => ({
+        name: r.name,
+        postalCodeCount: Number(r.postal_code_count),
     }));
 
     return Response.json(result);

--- a/src/api/routes/prices.ts
+++ b/src/api/routes/prices.ts
@@ -1,5 +1,4 @@
 import { sql } from '../db.ts';
-import { MUNICIPALITY_POSTAL_CODES } from '../../config/postalCodes.ts';
 
 /**
  * GET /api/prices?year=2024&building_type=all&municipality=Helsinki
@@ -22,13 +21,16 @@ export async function getPrices(url: URL): Promise<Response> {
         return Response.json({ error: 'year must be a number' }, { status: 400 });
     }
 
-    // Resolve postal codes for municipality filter
-    const postalCodeFilter = municipality
-        ? MUNICIPALITY_POSTAL_CODES[municipality] ?? null
-        : null;
-
-    if (municipality && !postalCodeFilter) {
-        return Response.json({ error: `Unknown municipality: ${municipality}` }, { status: 400 });
+    // Resolve postal codes for municipality filter from DB
+    let postalCodeFilter: string[] | null = null;
+    if (municipality) {
+        const rows = await sql`
+            SELECT code FROM postal_code WHERE municipality = ${municipality}
+        `;
+        if (rows.length === 0) {
+            return Response.json({ error: `Unknown municipality: ${municipality}` }, { status: 400 });
+        }
+        postalCodeFilter = rows.map(r => r.code);
     }
 
     const prevYear = year - 1;

--- a/src/config/fetchConfig.ts
+++ b/src/config/fetchConfig.ts
@@ -1,0 +1,98 @@
+/**
+ * Fetch configuration — master input is a list of municipality names.
+ *
+ * Postal codes are resolved dynamically at runtime via WFS API:
+ *   municipality name → municipality code → postal codes (WFS) → filter against stat.fi
+ */
+
+// ── Master input: municipalities to fetch ──
+
+/** Municipalities to include in data fetching. Add/remove names here. */
+export const TARGET_MUNICIPALITIES: string[] = [
+    'Helsinki',
+    'Espoo',
+    'Vantaa',
+    'Tampere',
+    'Pirkkala',
+    'Ylöjärvi',
+    'Kangasala',
+    'Nokia',
+];
+
+// ── Municipality name → code mapping ──
+
+/**
+ * Known municipality name → Tilastokeskus municipality code.
+ * WFS data uses codes (e.g. '091'), not names.
+ * Add new municipalities here when expanding TARGET_MUNICIPALITIES.
+ *
+ * Full list: https://stat.fi/fi/luokitukset/kunta/
+ */
+export const MUNICIPALITY_NAME_TO_CODE: ReadonlyMap<string, string> = new Map([
+    ['Helsinki', '091'],
+    ['Espoo', '049'],
+    ['Vantaa', '092'],
+    ['Tampere', '837'],
+    ['Pirkkala', '604'],
+    ['Ylöjärvi', '980'],
+    ['Kangasala', '211'],
+    ['Nokia', '536'],
+    ['Turku', '853'],
+    ['Oulu', '564'],
+    ['Jyväskylä', '179'],
+    ['Kuopio', '297'],
+    ['Lahti', '398'],
+    ['Pori', '609'],
+    ['Joensuu', '167'],
+    ['Lappeenranta', '405'],
+    ['Hämeenlinna', '109'],
+    ['Vaasa', '905'],
+    ['Seinäjoki', '743'],
+    ['Rovaniemi', '698'],
+    ['Kouvola', '286'],
+    ['Kotka', '285'],
+    ['Mikkeli', '491'],
+    ['Porvoo', '638'],
+    ['Rauma', '684'],
+    ['Kajaani', '205'],
+    ['Kokkola', '272'],
+    ['Lempäälä', '418'],
+    ['Järvenpää', '186'],
+    ['Kerava', '245'],
+    ['Kirkkonummi', '257'],
+    ['Nurmijärvi', '543'],
+    ['Tuusula', '858'],
+    ['Hyvinkää', '106'],
+    ['Riihimäki', '694'],
+    ['Sipoo', '753'],
+    ['Kauniainen', '235'],
+    ['Sastamala', '790'],
+    ['Valkeakoski', '908'],
+    ['Akaa', '020'],
+]);
+
+// ── Other fetch parameters ──
+
+/** Starting year for data fetch */
+export const FETCH_START_YEAR = 2018;
+
+/**
+ * Generate year range from FETCH_START_YEAR to current year (inclusive).
+ */
+export function generateYearRange(): string[] {
+    const currentYear = new Date().getFullYear();
+    const years: string[] = [];
+    for (let y = FETCH_START_YEAR; y <= currentYear; y++) {
+        years.push(String(y));
+    }
+    return years;
+}
+
+/** Default years to fetch (2018 → current year) */
+export const DEFAULT_YEARS: string[] = generateYearRange();
+
+/** Default building type codes from stat.fi */
+export const DEFAULT_BUILDING_TYPES: string[] = ['1', '2', '3', '5'];
+
+/** Default metric codes from stat.fi */
+export const DEFAULT_METRICS: string[] = ['keskihinta_aritm_nw', 'lkm_julk20'];

--- a/src/config/fetchConfig.ts
+++ b/src/config/fetchConfig.ts
@@ -17,6 +17,7 @@ export const TARGET_MUNICIPALITIES: string[] = [
     'Ylöjärvi',
     'Kangasala',
     'Nokia',
+    'Lempäälä'
 ];
 
 // ── Municipality name → code mapping ──

--- a/src/config/postalCodes.ts
+++ b/src/config/postalCodes.ts
@@ -1,119 +1,16 @@
 /**
- * Postal codes by municipality for housing price data.
- * Only includes postal codes that exist in Tilastokeskus stat.fi dataset (statfin_ashi_pxt_13mu).
- * Municipality codes from Tilastokeskus WFS (postialue:pno_tilasto_2024).
+ * @deprecated Use fetchConfig.ts instead. This file kept for backward compatibility.
+ *
+ * Postal codes are now resolved dynamically from municipality names via WFS API.
+ * Static exports removed — use MunicipalityResolver at runtime.
  */
 
-/** Municipality code → name mapping */
-export const MUNICIPALITY_CODES: Record<string, string> = {
-    '091': 'Helsinki',
-    '049': 'Espoo',
-    '092': 'Vantaa',
-    '837': 'Tampere',
-    '604': 'Pirkkala',
-    '980': 'Ylöjärvi',
-    '211': 'Kangasala',
-    '536': 'Nokia',
-};
-
-/** Municipality name → postal codes available in stat.fi */
-export const MUNICIPALITY_POSTAL_CODES: Record<string, string[]> = {
-    Helsinki: [
-        '00100', '00120', '00130', '00140', '00150', '00160', '00170', '00180',
-        '00200', '00210', '00220', '00240', '00250', '00260', '00270', '00280', '00290',
-        '00300', '00310', '00320', '00330', '00340', '00350', '00360', '00370', '00380', '00390',
-        '00400', '00410', '00420', '00430', '00440',
-        '00500', '00510', '00520', '00530', '00540', '00550', '00560', '00570', '00580', '00590',
-        '00600', '00610', '00620', '00630', '00640', '00650', '00660', '00670', '00680', '00690',
-        '00700', '00710', '00720', '00730', '00740', '00750', '00760', '00770', '00780', '00790',
-        '00800', '00810', '00820', '00830', '00840', '00850', '00870', '00880', '00890',
-        '00900', '00910', '00920', '00930', '00940', '00950', '00960', '00970', '00980', '00990',
-    ],
-    Espoo: [
-        '02100', '02110', '02120', '02130', '02140', '02150', '02160', '02170', '02180',
-        '02200', '02210', '02230', '02240', '02250', '02260', '02270', '02280',
-        '02300', '02320', '02330', '02340', '02360', '02380',
-        '02600', '02610', '02620', '02630', '02650', '02660', '02680',
-        '02710', '02720', '02730', '02740', '02750', '02760', '02770', '02780',
-        '02810', '02820', '02860', '02920', '02940', '02970',
-    ],
-    Vantaa: [
-        '01200', '01230', '01260', '01280',
-        '01300', '01340', '01350', '01360', '01370', '01380', '01390',
-        '01400', '01420', '01450', '01480', '01490',
-        '01510', '01520', '01530',
-        '01600', '01610', '01620', '01630', '01640', '01650', '01660', '01670', '01680', '01690',
-        '01700', '01710', '01720', '01730', '01740', '01750', '01760',
-    ],
-    Tampere: [
-        '33100', '33180', '33200', '33210', '33230', '33240', '33250', '33270',
-        '33300', '33310', '33330', '33340',
-        '33400', '33410', '33420',
-        '33500', '33520', '33530', '33540', '33560', '33580',
-        '33610', '33680',
-        '33700', '33710', '33720', '33730',
-        '33800', '33820', '33840', '33850', '33870', '33900',
-        '34240', '34260',
-    ],
-    Pirkkala: [
-        '33920', '33950', '33960', '33980',
-    ],
-    Ylöjärvi: [
-        '33430', '33450', '33470', '33480',
-        '34110', '34130', '34140',
-        '34300',
-        '39160', '39310', '39340',
-    ],
-    Kangasala: [
-        '36100', '36110', '36200', '36220', '36240', '36270', '36280',
-        '36420', '36430',
-        '36810', '36840',
-    ],
-    Nokia: [
-        '37100', '37120', '37130', '37140', '37150',
-        '37200', '37240',
-    ],
-};
-
-/** All supported municipalities (sorted) */
-export const MUNICIPALITIES: string[] = Object.keys(MUNICIPALITY_POSTAL_CODES).sort();
-
-/** All postal codes across all municipalities */
-export const ALL_POSTAL_CODES: string[] = Object.values(MUNICIPALITY_POSTAL_CODES).flat().sort();
-
-// Legacy exports for backward compatibility
-export const HELSINKI_POSTAL_CODES = MUNICIPALITY_POSTAL_CODES.Helsinki;
-export const ESPOO_POSTAL_CODES = MUNICIPALITY_POSTAL_CODES.Espoo;
-export const VANTAA_POSTAL_CODES = MUNICIPALITY_POSTAL_CODES.Vantaa;
-
-/** All PKS (pääkaupunkiseutu) postal codes combined */
-export const PKS_POSTAL_CODES: string[] = [
-    ...HELSINKI_POSTAL_CODES,
-    ...ESPOO_POSTAL_CODES,
-    ...VANTAA_POSTAL_CODES,
-];
-
-/** Starting year for data fetch */
-export const FETCH_START_YEAR = 2018;
-
-/**
- * Generate year range from FETCH_START_YEAR to current year (inclusive).
- * Years not available in the API will be filtered out by the extractor's validateConfig.
- */
-export function generateYearRange(): string[] {
-    const currentYear = new Date().getFullYear();
-    const years: string[] = [];
-    for (let y = FETCH_START_YEAR; y <= currentYear; y++) {
-        years.push(String(y));
-    }
-    return years;
-}
-
-/** Default years to fetch (2018 → current year) */
-export const DEFAULT_YEARS: string[] = generateYearRange();
-
-/** Default building type codes from stat.fi */
-export const DEFAULT_BUILDING_TYPES: string[] = ['1', '2', '3', '5'];
-
-/** Default metric codes from stat.fi */
-export const DEFAULT_METRICS: string[] = ['keskihinta_aritm_nw', 'lkm_julk20'];
+export {
+    TARGET_MUNICIPALITIES,
+    MUNICIPALITY_NAME_TO_CODE,
+    FETCH_START_YEAR,
+    generateYearRange,
+    DEFAULT_YEARS,
+    DEFAULT_BUILDING_TYPES,
+    DEFAULT_METRICS,
+} from './fetchConfig.ts';

--- a/src/extractor/DatasetExtractor.ts
+++ b/src/extractor/DatasetExtractor.ts
@@ -9,7 +9,7 @@ import type {
     Selection,
     ResponseFormat
 } from '../model/Models.ts';
-import { DEFAULT_BUILDING_TYPES, DEFAULT_METRICS } from '../config/postalCodes.ts';
+import { DEFAULT_BUILDING_TYPES, DEFAULT_METRICS } from '../config/fetchConfig.ts';
 import type { Logger } from 'pino';
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ import { DatasetExtractor } from "./extractor/DatasetExtractor.ts";
 import { DatasetTransformer } from "./transformer/DatasetTransformer.ts";
 import { STATFIN_BUILDING_TYPE_MAPPINGS } from "./transformer/StatfinBuildingTypes.ts";
 import { PxWebDatasetSource } from "./source/PxWebDatasetSource.ts";
-import { ALL_POSTAL_CODES, DEFAULT_YEARS } from "./config/postalCodes.ts";
+import { MunicipalityResolver } from "./resolver/MunicipalityResolver.ts";
+import { TARGET_MUNICIPALITIES, MUNICIPALITY_NAME_TO_CODE, DEFAULT_YEARS } from "./config/fetchConfig.ts";
 import type { DatasetMetadata, RawDataset, TransformResult, QueryConfig, PriceRecord } from "./model/Models.ts";
 import { createLogger } from './utils/Logger.ts';
 
@@ -21,12 +22,18 @@ async function main() {
     "https://pxdata.stat.fi/PXWeb/api/v1/en/StatFin/statfin_ashi_pxt_13mu.px";
 
   logger.info("statfin extract starting...");
+  logger.info(`Target municipalities: ${TARGET_MUNICIPALITIES.join(', ')}`);
+
+  // Step 0: Resolve municipality names → postal codes via WFS
+  const resolver = new MunicipalityResolver();
+  const postalCodes = await resolver.resolveFlat(TARGET_MUNICIPALITIES, MUNICIPALITY_NAME_TO_CODE);
+  logger.info(`Resolved ${postalCodes.length} postal codes from ${TARGET_MUNICIPALITIES.length} municipalities`);
 
   const dataSource: PxWebDatasetSource = new PxWebDatasetSource(datasetUrl);
   const extractor: DatasetExtractor = new DatasetExtractor();
 
   const queryConfig: QueryConfig = {
-    postalCodes: ALL_POSTAL_CODES,
+    postalCodes,
     years: DEFAULT_YEARS,
   };
 

--- a/src/resolver/MunicipalityResolver.ts
+++ b/src/resolver/MunicipalityResolver.ts
@@ -1,0 +1,123 @@
+import { PostalCodeGeometrySource, type PostalCodeFeature } from '../source/PostalCodeGeometrySource.ts';
+import { createLogger } from '../utils/Logger.ts';
+
+const logger = createLogger('MunicipalityResolver');
+
+/**
+ * Resolves municipality names → postal codes using Tilastokeskus WFS data.
+ *
+ * Flow: municipality name → municipality code → postal codes
+ * All resolved from a single WFS fetch (cached per instance).
+ */
+export class MunicipalityResolver {
+    private features: PostalCodeFeature[] | null = null;
+    private geometrySource: PostalCodeGeometrySource;
+
+    constructor(geometrySource?: PostalCodeGeometrySource) {
+        this.geometrySource = geometrySource ?? new PostalCodeGeometrySource();
+    }
+
+    /**
+     * Fetch and cache all WFS features (called once per run).
+     */
+    private async ensureFeatures(): Promise<PostalCodeFeature[]> {
+        if (!this.features) {
+            logger.info('Fetching WFS data for municipality resolution...');
+            this.features = await this.geometrySource.fetchAll();
+            logger.info(`Cached ${this.features.length} postal code features`);
+        }
+        return this.features;
+    }
+
+    /**
+     * Build a map of municipality name → municipality code from WFS data.
+     * Municipality names come from postal code area names, but WFS only gives
+     * us the municipality *code* per feature. We use Tilastokeskus's known
+     * municipality code mapping.
+     *
+     * Since WFS doesn't directly include municipality names, we derive them
+     * from the known MUNICIPALITY_NAMES mapping (passed in or built externally).
+     */
+    async getMunicipalityCodeMap(): Promise<Map<string, string>> {
+        const features = await this.ensureFeatures();
+        // WFS gives us unique municipality codes — collect them
+        const codes = new Set<string>();
+        for (const f of features) {
+            codes.add(f.municipality);
+        }
+        return new Map(); // Not directly available from WFS alone
+    }
+
+    /**
+     * Resolve municipality names to postal codes.
+     *
+     * @param municipalityNames List of municipality names (e.g. ['Helsinki', 'Tampere'])
+     * @param municipalityNameToCode Mapping of name → municipality code (e.g. 'Helsinki' → '091')
+     * @returns Map of municipality name → sorted postal code array
+     * @throws Error if any municipality name cannot be resolved to a code
+     */
+    async resolve(
+        municipalityNames: string[],
+        municipalityNameToCode: ReadonlyMap<string, string>,
+    ): Promise<Map<string, string[]>> {
+        const features = await this.ensureFeatures();
+
+        // Validate all names resolve to codes
+        const missingNames: string[] = [];
+        const codeToName = new Map<string, string>();
+
+        for (const name of municipalityNames) {
+            const code = municipalityNameToCode.get(name);
+            if (!code) {
+                missingNames.push(name);
+            } else {
+                codeToName.set(code, name);
+            }
+        }
+
+        if (missingNames.length > 0) {
+            throw new Error(
+                `Unknown municipality names (no code mapping found): ${missingNames.join(', ')}. ` +
+                `Add them to MUNICIPALITY_NAME_TO_CODE in fetchConfig.ts`
+            );
+        }
+
+        // Group postal codes by municipality code
+        const result = new Map<string, string[]>();
+        for (const name of municipalityNames) {
+            result.set(name, []);
+        }
+
+        const targetCodes = new Set(codeToName.keys());
+
+        for (const feature of features) {
+            if (targetCodes.has(feature.municipality)) {
+                const name = codeToName.get(feature.municipality)!;
+                result.get(name)!.push(feature.postalCode);
+            }
+        }
+
+        // Sort postal codes and log stats
+        for (const [name, codes] of result) {
+            codes.sort();
+            logger.info(`${name}: ${codes.length} postal codes`);
+        }
+
+        return result;
+    }
+
+    /**
+     * Convenience: resolve municipality names to a flat sorted array of postal codes.
+     */
+    async resolveFlat(
+        municipalityNames: string[],
+        municipalityNameToCode: ReadonlyMap<string, string>,
+    ): Promise<string[]> {
+        const map = await this.resolve(municipalityNames, municipalityNameToCode);
+        const all: string[] = [];
+        for (const codes of map.values()) {
+            all.push(...codes);
+        }
+        return all.sort();
+    }
+}


### PR DESCRIPTION
- Master input is now a list of municipality names in fetchConfig.ts
- MunicipalityResolver fetches WFS data once and resolves municipality name → code → postal codes dynamically
- Removed hardcoded MUNICIPALITY_POSTAL_CODES from config
- API routes now query postal_code DB table for municipality filtering
- postalCodes.ts kept as backward-compat re-export shim
- Added ~40 municipality name→code mappings for easy expansion